### PR TITLE
Merge updates of Aveva to AVEVA, and OSIsoft updates

### DIFF
--- a/classification.xml
+++ b/classification.xml
@@ -218,13 +218,11 @@
    </Row>
    <Row ss:AutoFitHeight="0" ss:Height="15">
     <Cell><Data ss:Type="String">MAP</Data></Cell>
-    <Cell ss:Index="3"><Data ss:Type="String">cloud</Data></Cell>
-    <Cell ss:StyleID="s63"><Data ss:Type="String">AVEVA-Data-Hub</Data></Cell>
+    <Cell ss:Index="3"><Data ss:Type="String">cloud_adh</Data></Cell>    
    </Row>
    <Row ss:AutoFitHeight="0" ss:Height="15">
     <Cell><Data ss:Type="String">apply-ALL</Data></Cell>
-    <Cell ss:Index="3"><Data ss:Type="String">cloud</Data></Cell>
-    <Cell ss:StyleID="s63"><Data ss:Type="String">AVEVA-Data-Hub</Data></Cell>
+    <Cell ss:Index="3"><Data ss:Type="String">cloud_adh</Data></Cell>
    </Row>
    <Row ss:AutoFitHeight="0">
     <Cell><Data ss:Type="String">default</Data></Cell>


### PR DESCRIPTION
I believe all the GD “Aveva”s are now “AVEVA”s. Sure hope so… The updates are in my branch, pbi-274054-Aveva-renaming, and I’ll create a PR to request to merge to Development. After this is complete, I’ll create a new branch to handle the PI to OCS change to PI to Data Hub (I see the list of exact changes in ADO, thanks, Vicki!!)

For the “OSIsoft”s, there are a few places where I did not change them. Should I change them?

In the 3 intro topics (I think Vicki was doing these, but if not, I’m happy to do so):
• What is OSIsoft Could Services?
• Who uses OSIsoft Could Services?
• What does OSIsoft Could Services do?
OSIsoft Message Format
UI field names/buttons (eg Click Connect to OSIsoft Cloud Services in PI to OCS topics, I think)
In URLs
The Release Notes topics for PI to OCS, and Power BI Connector, both include a trademark/product name block. Lots of “OSIsoft”s in those.