### PR TITLE
Pbi 309566 toc reorg

### DIFF
--- a/content/toc.yml
+++ b/content/toc.yml
@@ -12,9 +12,9 @@
    - topicUid: cnnxt-setup
      items:
      - topicUid: subscribe-adh
-     - topicUid: create-folders
      - topicUid: ccNamespaces
        items: 
+       - topicUid: create-folders
        - topicUid: bpNamespaces
      - topicUid: manage-permissions-connect
        items:


### PR DESCRIPTION
Revised TOC update from OCS to ADH, which includes the ADH Connect topics. Also moved the Folders and Namespaces topics from Setup to be under Set Up AVEVA Data Hub in AVEVA Connect.