### PR TITLE
444657 filter out non indexed types on stream creation

### DIFF
--- a/content/add-organize-data/store-data/streams/streams-manage-streams.md
+++ b/content/add-organize-data/store-data/streams/streams-manage-streams.md
@@ -12,43 +12,41 @@ The following best practices are recommended when [creating streams](#add-a-stre
 
 - Ensure that the default stream permissions are configured before you begin creating streams. While you can later do a bulk update of stream permissions, it is easier to configure the default permissions before the streams are created. Permissions that vary from the default are configured on the individual streams.
 
-- Use a meaningful pattern when naming streams. For example, a naming pattern might be "*Company_name*.{*Region*}.{*Site*}.{*Equipment*}". This makes it possible for tools, such as metadata rules, to use this naming schema to find relevant data. Metadata like this can also be stored as key-value pairs on the stream, but a well-defined naming pattern allows metadata to be generated automatically.
+- Use a meaningful pattern when naming streams. For example, a naming pattern might be "*Company_name*.{*Region*}.{*Site*}.{*Equipment*}". This makes it possible for tools, such as metadata rules, to use this naming schema to find relevant data. Metadata like this can also be stored as key-value pairs on the stream, but a well-defined naming pattern allows metadata to be generated automatically. 
 
 - Use the stream description field, metadata, and tags to capture any other relevant information about the stream. This information is useful to search for specific streams in the system, especially as systems become large. If possible, use consistent patterns in description, metadata, and tags.
 
-   - Use metadata for information that follows a specific or consistent pattern, such as the location, manufacturer, and site.
-
+   - Use metadata for information that follows a specific or consistent pattern, such as the location, manufacturer, and site. 
+   
    - Use tags for simple information about the stream that does not adhere to any particular pattern.
-
+   
    - Use the description field for longer descriptions of the stream and what it represents.
 
 ## Add a stream
 
-Sequential Data Store (SDS) stream data are values or events of the same SDS type. SDS stream data are stored in the Sequential Data Store and indexed by one or more properties defined by the stream's SDS type.
+Sequential Data Store (SDS) stream data are values or events of the same SDS type. SDS stream data are stored in the Sequential Data Store and indexed by one or more properties defined by the stream's SDS type. 
 
 To add a stream, follow these steps:
 
 1. In the left pane, select **Data Management** > **Sequential Data Store**.
-
+   
 1. From the **Streams** dropdown list, select **Streams**.
-
+ 
 1. Select **Add Stream**.
 
 1. In the `Add Stream` pane, complete the following fields:
 
    - **Id** &ndash; (Optional) Enter an identifier for referencing the stream. If you do not enter an Id, a GUID is generated.
 
-   - **Name** &ndash; (Optional) Enter a user-friendly name for the stream. If you do not enter a name, the **Id** is used as the name.
+   - **Name** &ndash; (Optional) Enter a user-friendly name for the stream. If you do not enter a name, the **Id** is used as the name. 
 
    - **Description** &ndash; (Optional) Enter a user-friendly description of the stream.
 
    - **Type** &ndash; SDS type identifier of the type used in this stream.
 
-       **Important:** Only types that have a key configured are available for selection. If you want to use a type that is not listed, you must first configure a key. For more information see <xref:gpTypes>.
-
 1. To add tags to the stream, select the **Tags** tab.
 
-1. For each tag you want to add, enter the name of the tag in the **New Tag** field, and then select **+**.
+1. For each tag you want to add, enter the name of the tag in the **New Tag** field, and then select **+**. 
 
 1. Select the **Metadata** tab.
 

--- a/content/add-organize-data/store-data/streams/streams-manage-streams.md
+++ b/content/add-organize-data/store-data/streams/streams-manage-streams.md
@@ -44,6 +44,8 @@ To add a stream, follow these steps:
 
    - **Type** &ndash; SDS type identifier of the type used in this stream.
 
+       **Important:** Only types that have a key configured are available for selection. If you want to use a type that is not listed, you must first configure a key. For more information see <xref:gpTypes>.
+
 1. To add tags to the stream, select the **Tags** tab.
 
 1. For each tag you want to add, enter the name of the tag in the **New Tag** field, and then select **+**. 

--- a/content/add-organize-data/store-data/streams/streams-manage-streams.md
+++ b/content/add-organize-data/store-data/streams/streams-manage-streams.md
@@ -12,41 +12,43 @@ The following best practices are recommended when [creating streams](#add-a-stre
 
 - Ensure that the default stream permissions are configured before you begin creating streams. While you can later do a bulk update of stream permissions, it is easier to configure the default permissions before the streams are created. Permissions that vary from the default are configured on the individual streams.
 
-- Use a meaningful pattern when naming streams. For example, a naming pattern might be "*Company_name*.{*Region*}.{*Site*}.{*Equipment*}". This makes it possible for tools, such as metadata rules, to use this naming schema to find relevant data. Metadata like this can also be stored as key-value pairs on the stream, but a well-defined naming pattern allows metadata to be generated automatically. 
+- Use a meaningful pattern when naming streams. For example, a naming pattern might be "*Company_name*.{*Region*}.{*Site*}.{*Equipment*}". This makes it possible for tools, such as metadata rules, to use this naming schema to find relevant data. Metadata like this can also be stored as key-value pairs on the stream, but a well-defined naming pattern allows metadata to be generated automatically.
 
 - Use the stream description field, metadata, and tags to capture any other relevant information about the stream. This information is useful to search for specific streams in the system, especially as systems become large. If possible, use consistent patterns in description, metadata, and tags.
 
-   - Use metadata for information that follows a specific or consistent pattern, such as the location, manufacturer, and site. 
-   
+   - Use metadata for information that follows a specific or consistent pattern, such as the location, manufacturer, and site.
+
    - Use tags for simple information about the stream that does not adhere to any particular pattern.
-   
+
    - Use the description field for longer descriptions of the stream and what it represents.
 
 ## Add a stream
 
-Sequential Data Store (SDS) stream data are values or events of the same SDS type. SDS stream data are stored in the Sequential Data Store and indexed by one or more properties defined by the stream's SDS type. 
+Sequential Data Store (SDS) stream data are values or events of the same SDS type. SDS stream data are stored in the Sequential Data Store and indexed by one or more properties defined by the stream's SDS type.
 
 To add a stream, follow these steps:
 
 1. In the left pane, select **Data Management** > **Sequential Data Store**.
-   
+
 1. From the **Streams** dropdown list, select **Streams**.
- 
+
 1. Select **Add Stream**.
 
 1. In the `Add Stream` pane, complete the following fields:
 
    - **Id** &ndash; (Optional) Enter an identifier for referencing the stream. If you do not enter an Id, a GUID is generated.
 
-   - **Name** &ndash; (Optional) Enter a user-friendly name for the stream. If you do not enter a name, the **Id** is used as the name. 
+   - **Name** &ndash; (Optional) Enter a user-friendly name for the stream. If you do not enter a name, the **Id** is used as the name.
 
    - **Description** &ndash; (Optional) Enter a user-friendly description of the stream.
 
    - **Type** &ndash; SDS type identifier of the type used in this stream.
 
+       **Important:** Only types that have a key configured are available for selection. If you want to use a type that is not listed, you must first configure a key. For more information see <xref:gpTypes>.
+
 1. To add tags to the stream, select the **Tags** tab.
 
-1. For each tag you want to add, enter the name of the tag in the **New Tag** field, and then select **+**. 
+1. For each tag you want to add, enter the name of the tag in the **New Tag** field, and then select **+**.
 
 1. Select the **Metadata** tab.
 

--- a/content/add-organize-data/store-data/types/types-procedure.md
+++ b/content/add-organize-data/store-data/types/types-procedure.md
@@ -35,6 +35,8 @@ To add a base type:
 1. For each property to add to the type, select **Add Property** and complete the following fields:
  
     - **Key** - Select the checkbox to indicate the property is an index. Only system SDS types can be designated as keys. You can select up to three properties as indexes. Drag and drop the properties in the list to reorder the index keys.
+
+         **Important:** You can only create streams from types that have an indexed defined. In other words, the type must have a key defined, or the type will not be available for selection when [adding a stream](xref:streams-manage-streams#add-a-stream).
     
     - **Id** - Enter the identifier for referencing the property.
     

--- a/content/add-organize-data/store-data/types/types-procedure.md
+++ b/content/add-organize-data/store-data/types/types-procedure.md
@@ -6,11 +6,11 @@ uid: gpTypes
 
 Sequential Data Store (SDS) types define the shape and structure of events and how to associate events with streams of data. Once created, you cannot modify a type. You can add one of two types: **Standard Types** or **Enum Types**.
 
-**Tip:** For a list of the supported property types, see [Supported types](xref:sdsTypes#sdstypecode).
+**Tip:** For a list of the supported property types, see [Supported types](xref:sdsTypes#sdstypecode). 
 
 # [Standard type](#tab/tabid-1)
 
-To add a base type:
+To add a base type: 
 
 1. In the left pane, select **Data Management** > **Sequential Data Store**.
 
@@ -25,29 +25,27 @@ To add a base type:
 1. Complete the following fields:
 
     - **Id** - Enter the Id for the type.
-
+    
     - **Name** - (Optional) Enter a user-friendly name. If you do not enter a name, the **Id** is used as the name.
-
+    
     - **Description** - (Optional) Enter a user-friendly description of the type.
-
+    
     - **Type** - (Optional) To base the new type on an existing standard type, select the existing type from the dropdown. The new type inherits the properties of the base type. Inherited properties are read only and cannot be modified.
 
 1. For each property to add to the type, select **Add Property** and complete the following fields:
-
+ 
     - **Key** - Select the checkbox to indicate the property is an index. Only system SDS types can be designated as keys. You can select up to three properties as indexes. Drag and drop the properties in the list to reorder the index keys.
-
-        **Important:** You can only create streams from types that have an indexed defined. In other words, the type must have a key defined, or the type will not be available for selection when [adding a stream](xref:streams-manage-streams#add-a-stream).
-
+    
     - **Id** - Enter the identifier for referencing the property.
-
-    - **Name** - Enter the name of the property. If you do not enter a name, the **Id** is used as the name.
-
+    
+    - **Name** - Enter the name of the property. If you do not enter a name, the **Id** is used as the name. 
+    
     - **Base Type** - Select the SDS type of the property from the dropdown.
-
+    
         **Note:** To find the type in the list, filter the property types by entering text in the **Filter Types** field and use the **System** or **Tenant** controls to include or exclude these types. **Tenant** includes any types that were previously created in the selected namespace for a particular tenant. **System** includes SDS types that are provided and defined such as `string`, `integer`, `double`, `datetime`, and `Boolean`.
-
-    - **UOM** - (Optional) Select a unit of measure for the property from the list.
-
+    
+    - **UOM** - (Optional) Select a unit of measure for the property from the list. 
+   
 1. To save the type, select **Save**.
 
 # [Enum type](#tab/tabid-2)
@@ -69,17 +67,17 @@ To add a enum type:
 1. In the `Add Enum Type` pane, complete the following fields:
 
     - **Id** - Enter the Id for the type.
-
+    
     - **Name** - (Optional) Enter a user-friendly name. If you do not enter a name, the **Id** is used as the name.
-
+    
     - **Description** - (Optional) Enter a user-friendly description of the type.
-
+    
     - **Enum Type** - Select the enum type from the dropdown.
 
 1. For each property to add to the enum type, select **Add Property** and complete the following fields:
-
+ 
     - **Id** - Enter the identifier for referencing the property.
-
+    
     - **Value** - Enter the numeric value of the property.
 
         **Note:** Accepted numeric values change based on the selected **Enum Type**. Refer to the following table for accepted values for each type.
@@ -96,9 +94,9 @@ To add a enum type:
         | UInt_X_Enum | ✔ | ✖ | ✖ |
 
         <sup>1</sup>: Integer<br>
-        <sup>2</sup>: Negative Integer<br>
+        <sup>2</sup>: Negative Integer<br> 
         <sup>3</sup>: Nullable fields can be left empty
-
+    
 1. To save the type, select **Save**.
 
 ***

--- a/content/add-organize-data/store-data/types/types-procedure.md
+++ b/content/add-organize-data/store-data/types/types-procedure.md
@@ -6,11 +6,11 @@ uid: gpTypes
 
 Sequential Data Store (SDS) types define the shape and structure of events and how to associate events with streams of data. Once created, you cannot modify a type. You can add one of two types: **Standard Types** or **Enum Types**.
 
-**Tip:** For a list of the supported property types, see [Supported types](xref:sdsTypes#sdstypecode). 
+**Tip:** For a list of the supported property types, see [Supported types](xref:sdsTypes#sdstypecode).
 
 # [Standard type](#tab/tabid-1)
 
-To add a base type: 
+To add a base type:
 
 1. In the left pane, select **Data Management** > **Sequential Data Store**.
 
@@ -25,27 +25,29 @@ To add a base type:
 1. Complete the following fields:
 
     - **Id** - Enter the Id for the type.
-    
+
     - **Name** - (Optional) Enter a user-friendly name. If you do not enter a name, the **Id** is used as the name.
-    
+
     - **Description** - (Optional) Enter a user-friendly description of the type.
-    
+
     - **Type** - (Optional) To base the new type on an existing standard type, select the existing type from the dropdown. The new type inherits the properties of the base type. Inherited properties are read only and cannot be modified.
 
 1. For each property to add to the type, select **Add Property** and complete the following fields:
- 
+
     - **Key** - Select the checkbox to indicate the property is an index. Only system SDS types can be designated as keys. You can select up to three properties as indexes. Drag and drop the properties in the list to reorder the index keys.
-    
+
+        **Important:** You can only create streams from types that have an indexed defined. In other words, the type must have a key defined, or the type will not be available for selection when [adding a stream](xref:streams-manage-streams#add-a-stream).
+
     - **Id** - Enter the identifier for referencing the property.
-    
-    - **Name** - Enter the name of the property. If you do not enter a name, the **Id** is used as the name. 
-    
+
+    - **Name** - Enter the name of the property. If you do not enter a name, the **Id** is used as the name.
+
     - **Base Type** - Select the SDS type of the property from the dropdown.
-    
+
         **Note:** To find the type in the list, filter the property types by entering text in the **Filter Types** field and use the **System** or **Tenant** controls to include or exclude these types. **Tenant** includes any types that were previously created in the selected namespace for a particular tenant. **System** includes SDS types that are provided and defined such as `string`, `integer`, `double`, `datetime`, and `Boolean`.
-    
-    - **UOM** - (Optional) Select a unit of measure for the property from the list. 
-   
+
+    - **UOM** - (Optional) Select a unit of measure for the property from the list.
+
 1. To save the type, select **Save**.
 
 # [Enum type](#tab/tabid-2)
@@ -67,17 +69,17 @@ To add a enum type:
 1. In the `Add Enum Type` pane, complete the following fields:
 
     - **Id** - Enter the Id for the type.
-    
+
     - **Name** - (Optional) Enter a user-friendly name. If you do not enter a name, the **Id** is used as the name.
-    
+
     - **Description** - (Optional) Enter a user-friendly description of the type.
-    
+
     - **Enum Type** - Select the enum type from the dropdown.
 
 1. For each property to add to the enum type, select **Add Property** and complete the following fields:
- 
+
     - **Id** - Enter the identifier for referencing the property.
-    
+
     - **Value** - Enter the numeric value of the property.
 
         **Note:** Accepted numeric values change based on the selected **Enum Type**. Refer to the following table for accepted values for each type.
@@ -94,9 +96,9 @@ To add a enum type:
         | UInt_X_Enum | ✔ | ✖ | ✖ |
 
         <sup>1</sup>: Integer<br>
-        <sup>2</sup>: Negative Integer<br> 
+        <sup>2</sup>: Negative Integer<br>
         <sup>3</sup>: Nullable fields can be left empty
-    
+
 1. To save the type, select **Save**.
 
 ***


### PR DESCRIPTION
Hi Prianon,

Can you please review my doc changes for the two stories that you worked on this sprint? I added some notes on how types must have a key defined or you can't create a stream with them. These doc changes are for the following stories in ADO: [418826](https://dev.azure.com/osieng/engineering/_workitems/edit/418826) and [418825](https://dev.azure.com/osieng/engineering/_workitems/edit/418825)

The diffs are a little difficult to read without context. You may want to read them in my published dev environment: 

- https://aveva-dev.zoominsoftware.io/bundle/data-hub-444657-filter-out-non-indexed-types-on-stream-creation/page/add-organize-data/store-data/types/types-procedure.html (step 6, key bullet)
- https://aveva-dev.zoominsoftware.io/bundle/data-hub-444657-filter-out-non-indexed-types-on-stream-creation/page/add-organize-data/store-data/streams/streams-manage-streams.html#add-a-stream (step 4, type bullet)

