### PR TITLE
454224 increase fidelity of trend data export

### DIFF
--- a/content/toc.yml
+++ b/content/toc.yml
@@ -191,6 +191,7 @@
 - topicUid: lpvisualizedata
   items:
   - topicUid: CreateTrendSession
+  - topicUid: download-trend-data
   - topicUid: TrendUserInterface
     items:
     - topicUid: LegendTableReference

--- a/content/visualize-data/download-trend-data.md
+++ b/content/visualize-data/download-trend-data.md
@@ -1,0 +1,5 @@
+---
+uid: download-trend-data
+---
+
+# Download trend data

--- a/content/visualize-data/download-trend-data.md
+++ b/content/visualize-data/download-trend-data.md
@@ -4,7 +4,7 @@ uid: download-trend-data
 
 # Download trend data
 
-After you create a trend session that includes traces from assets, streams, or both, you can download the data depicted in trend session as a .csv file.
+After you create a trend session that includes traces from assets, streams, or both, you can download the data depicted in the trend session as a .csv file.
 
 1. In the left pane, select **Visualization** > **Trend**.
 

--- a/content/visualize-data/download-trend-data.md
+++ b/content/visualize-data/download-trend-data.md
@@ -22,4 +22,4 @@ After you create a trend session that includes traces from assets, streams, or b
 
 The selected trend session data is downloaded as .csv files.
 
-**Note:** When downloading trend session data, the data is not retrieved from the trend session—rather, the data is retrieved from the assets and streams. This approach allows the downloaded data be be more accurate, as the the data does not include interpolated or calculated data included in the trend session.
+**Note:** When downloading trend session data, the data is not retrieved from the trend session—rather, the data is retrieved from the assets and streams. This approach allows the downloaded data to include the actual stream data points, as the the data does not include interpolated or calculated data included in the trend session.

--- a/content/visualize-data/download-trend-data.md
+++ b/content/visualize-data/download-trend-data.md
@@ -3,3 +3,23 @@ uid: download-trend-data
 ---
 
 # Download trend data
+
+After you create a trend session that includes traces from assets, streams, or both, you can download the data depicted in trend session as a .csv file.
+
+1. In the left pane, select **Visualization** > **Trend**.
+
+1. Create a trend session using the instructions available in <xref:CreateTrendSession>.
+
+1. From the toolbar, select **Download CSV**.
+
+1. Select the data from the trend session that you want to download. Each option is downloaded as a separate .csv file.
+
+   - **Trend Data**: Downloads the data depicted in the [Trend pane](xref:TrendUserInterface).
+
+   - **UOM/Summary Data** Downloads the data listed in the [Legend table](xref:TrendUserInterface).
+
+1. Select **Download**.
+
+The selected trend session data is downloaded as .csv files.
+
+**Note:** When downloading trend session data, the data is not retrieved from the trend session—rather, the data is retrieved from the assets and streams. This approach allows the downloaded data be be more accurate, as the the data does not include interpolated or calculated data included in the trend session.


### PR DESCRIPTION
@osisoft-imousa, can you please review my first draft of documentation for [454224](https://dev.azure.com/osieng/engineering/_workitems/edit/454224)?

This doc PR addressed two things:

1. There was a hole in the documentation prior to this PR. Previously, there were no instructions on how to export data from a Trend session.

1. I added a note explaining that when you export data from Trend, the data pulled for the CSV is pulled directly from streams/assets rather than the trend session (the note on line 25). This note in particular needs your review, as I think I may have the wording wrong on what is technically happening behind the scenes. I could use your help with this--When we export the trend data, what are we doing that makes the data more accurate than the previous approach?