### PR TITLE
455125 consolidate csv logic

### DIFF
--- a/content/add-organize-data/store-data/streams/streams-download-data.md
+++ b/content/add-organize-data/store-data/streams/streams-download-data.md
@@ -1,0 +1,27 @@
+---
+uid: streams-download-data
+---
+
+# Download stream data
+
+While viewing streams in the Sequential Data Store, you can download the streams listed on screen as a .csv file.
+
+1. In the left pane, select **Data Management** > **Sequential Data Store**.
+
+1. From the upper-left dropdown menu, ensure **Streams** is selected.
+
+1. (Optional) Search or filter the page for the streams that you want to download in .csv format.
+
+    Use the **Search for Streams** field to query for specific streams. For more information on querying for specific streams, see <xref:Search>.
+
+    Use the **Filter Communities** pane to filter for streams from a specific community.
+
+1. (Optional) Choose the streams that you want to include in the download.
+
+    - To download all streams for your current search and filter settings, select no streams and continue to the next step.
+
+    - To download specific streams listed on the page, select their checkboxes and continue to the next step.
+
+1. Select **More options** ![More options](../../../_icons/default/dots-vertical.svg) > **Download as CSV**.
+
+The .csv file of stream data is downloaded to your computer. The .csv will only include streams that you have searched for, filtered for, or selected.

--- a/content/toc.yml
+++ b/content/toc.yml
@@ -70,6 +70,7 @@
               - topicUid: streams-edit-event
               - topicUid: streams-remove-event
             - topicUid: streams-manage-stream-permissions
+            - topicUid: streams-download-data
         - topicUid: ccTypes
           items:
             - topicUid: bpTypes

--- a/content/toc.yml
+++ b/content/toc.yml
@@ -192,6 +192,7 @@
 - topicUid: lpvisualizedata
   items:
   - topicUid: CreateTrendSession
+  - topicUid: download-trend-data
   - topicUid: TrendUserInterface
     items:
     - topicUid: LegendTableReference

--- a/content/visualize-data/download-trend-data.md
+++ b/content/visualize-data/download-trend-data.md
@@ -1,0 +1,24 @@
+---
+uid: download-trend-data
+---
+
+# Download trend data
+
+After you create a trend session that includes traces from assets, streams, or both, you can download the data depicted in trend session as a .csv file.
+
+1. In the left pane, select **Visualization** > **Trend**.
+
+1. Create a trend session using the instructions available in <xref:CreateTrendSession>.
+
+1. From the toolbar, select **Download CSV**.
+
+1. Select the data from the trend session that you want to download. Each option is downloaded as a separate .csv file.
+
+    - **Trend Data**: Downloads the data depicted in the [Trend pane](xref:TrendUserInterface#trend-pane).
+    - **UOM/Summary Data** Downloads the data listed in the [Legend table](xref:TrendUserInterface#legend-table).
+
+1. Select **Download**.
+
+The selected trend session data is downloaded as .csv files.
+
+**Note:** When downloading trend session data, the data is not retrieved from the trend session—rather, the data is retrieved from the assets and streams. This approach allows the downloaded data be be more accurate, as the the data does not include interpolated or calculated data included in the trend session.

--- a/content/visualize-data/download-trend-data.md
+++ b/content/visualize-data/download-trend-data.md
@@ -14,8 +14,9 @@ After you create a trend session that includes traces from assets, streams, or b
 
 1. Select the data from the trend session that you want to download. Each option is downloaded as a separate .csv file.
 
-    - **Trend Data**: Downloads the data depicted in the [Trend pane](xref:TrendUserInterface#trend-pane).
-    - **UOM/Summary Data** Downloads the data listed in the [Legend table](xref:TrendUserInterface#legend-table).
+   - **Trend Data**: Downloads the data depicted in the [Trend pane](xref:TrendUserInterface).
+
+   - **UOM/Summary Data** Downloads the data listed in the [Legend table](xref:TrendUserInterface).
 
 1. Select **Download**.
 


### PR DESCRIPTION
Hi Brian,

I updated the documentation for the button text that you updated for [383673](https://dev.azure.com/osieng/engineering/_workitems/edit/383673).

Prior to your work on 383673, the documentation had gaps about how to download data as CSVs from the following locations:

- "Sequential Data Store > Streams > Download as CSV"
- "Trend > Download CSV"

Therefore I added two new topics on how to perform the download using the "Download ..." button.

I did not update the wording for "Data Collection > PI to Data Hub Agents > View/Edit Transfer" due to [454229](https://dev.azure.com/osieng/engineering/_workitems/edit/454229) being completed by another team.